### PR TITLE
remove unecessary setTimeout in functions.spec

### DIFF
--- a/test/specs/functions.spec.js
+++ b/test/specs/functions.spec.js
@@ -286,13 +286,10 @@ describe("Main", function() {
   describe("#createCircle", function() {
     var radius, circle;
 
-    it("should be a function", function(done) {
-      setTimeout(function() {
-        (typeof createCircle).should.equal("function");
-        radius = 4;
-        circle = createCircle(radius);
-        done();
-      }, 1000);
+    it("should be a function", function() {
+      (typeof createCircle).should.equal("function");
+      radius = 4;
+      circle = createCircle(radius);
     });
 
     it("should return a circle object with the properties circumference and area", function() {


### PR DESCRIPTION
`git blame` shows @mrbarbasa added this

```diff
   describe("#createCircle", function() {
-    var radius = 4;
-    var circle = createCircle(radius);
-
-    it("should be a function", function() {
-      (typeof window.createCircle).should.equal("function");
+    var radius, circle;
+
+    it("should be a function", function(done) {
+      setTimeout(function() {
+        (typeof window.createCircle).should.equal("function");
+        radius = 4;
+        circle = createCircle(radius);
+        done();
+      }, 1000);
     });
```

not sure why it's here, merge this PR to remove the `setTimeout`